### PR TITLE
fix: replace dmesg with the more stable lspci command

### DIFF
--- a/benchmark-scripts/format_avc_mp4.sh
+++ b/benchmark-scripts/format_avc_mp4.sh
@@ -19,43 +19,8 @@ show_help() {
 WIDTH=3840
 HEIGHT=2160
 FPS=15
-HAS_FLEX_140=0
-HAS_FLEX_170=0
-HAS_ARC=0
-#HAS_iGPU=0
 
-get_gpu_devices() {
-        has_gpu=0
-        has_any_intel_non_server_gpu=`dmesg | grep -i "class 0x030000" | grep "8086"`
-        has_any_intel_server_gpu=`dmesg | grep -i "class 0x038000" | grep "8086"`
-        has_flex_170=`echo "$has_any_intel_server_gpu" | grep -i "56C0"`
-        has_flex_140=`echo "$has_any_intel_server_gpu" | grep -i "56C1"`
-        has_arc=`echo "$has_any_intel_non_server_gpu" | grep -iE "5690|5691|5692|56A0|56A1|56A2|5693|5694|5695|5698|56A5|56A6|56B0|56B1|5696|5697|56A3|56A4|56B2|56B3"`
-
-        if [ -z "$has_any_intel_non_server_gpu" ] && [ -z "$has_any_intel_server_gpu" ]
-        then
-                echo "No Intel GPUs found"
-                return
-        fi
-        #echo "GPU exists!"
-        if [ ! -z "$has_flex_140" ]
-        then
-                HAS_FLEX_140=1
-        fi
-        if [ ! -z "$has_flex_170" ]
-        then
-                HAS_FLEX_170=1
-        fi
-        if [ ! -z "$has_arc" ]
-        then
-                HAS_ARC=1
-        fi
-
-        #echo "HAS_FLEX_140=$HAS_FLEX_140, HAS_FLEX_170=$HAS_FLEX_170, HAS_ARC=$HAS_ARC"
-}
-
-
-get_gpu_devices
+source ../get-gpu-info.sh
 
 if [ -z "$2" ]
 then

--- a/get-gpu-info.sh
+++ b/get-gpu-info.sh
@@ -14,13 +14,11 @@ GPU_NUM_170=0
 
 #get_gpu_devices() {
 	has_gpu=0
-	has_any_intel_non_server_gpu=`dmesg | grep -i "class 0x030000" | grep "8086"`
-	has_any_intel_server_gpu=`dmesg | grep -i "class 0x038000" | grep "8086"`
-	has_flex_170=`echo "$has_any_intel_server_gpu" | grep -i "56C0"`
-	has_flex_140=`echo "$has_any_intel_server_gpu" | grep -i "56C1"`
-	has_arc=`echo "$has_any_intel_non_server_gpu" | grep -iE "5690|5691|5692|56A0|56A1|56A2|5693|5694|5695|5698|56A5|56A6|56B0|56B1|5696|5697|56A3|56A4|56B2|56B3"`
+	has_flex_170=`lspci -d :56C0`
+	has_flex_140=`lspci -d :56C1`
+	has_arc=`lspci | grep -iE "5690|5691|5692|56A0|56A1|56A2|5693|5694|5695|5698|56A5|56A6|56B0|56B1|5696|5697|56A3|56A4|56B2|56B3"`
 
-	if [ -z "$has_any_intel_non_server_gpu" ] && [ -z "$has_any_intel_server_gpu" ] 
+	if [ -z "$has_flex_170" ] && [ -z "$has_flex_140" ] && [ -z "$has_arc" ] 
 	then
 		echo "No Intel GPUs found"
 		return


### PR DESCRIPTION
close #34

_The PR review is to check for sustainability and correctness.  Sustainability is actually more business critical as correctness is largely tested into the code over time.   Its useful to keep in mind that SW often outlives the HW it was written for and engineers move from job to job so it is critical that code developed for Intel be supportable across many years.  It is up to the submitter and reviewer to look at the code from a perspective of what if we have to debug this 3 years from now after the author is no longer available and defect databases have been lost.  Yes, that happens all the time when we are working with time scales of more than 2 years.  When reviewing your code it is important to look at it from this perspective._

Author Mandatory (to be filled by PR Author/Submitter)
------------------------------------------------------
- Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.  
- Those checklist items which are not marked are considered as not applicable for the PR change.  
- Items marked with an asterisk suffix are mandatory items to check and if not marked will be treated as non-compliant pull requests by the developers for Inner Source Development Model (ISDM) compliance

### PULL DESCRIPTION
Fix: replace dmesg with lspci to get GPU devices

### REFERENCES
Reference URL for issue tracking (Github): **\<URL to be filled>**

- [x] Added label to the Pull Request for easier discoverability and search

### CODE MAINTAINABILITY
- [x] **_Commit Message meets guidelines as indicated in the URL\*_**
	- https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md
- [x] **_Every commit is a single defect fix and does not mix feature addition or changes\*_**
- [ ] Added required new tests relevant to the changes
	- [ ] PR contains URL links to functional tests executed with the new tests 
- [ ] Updated Documentation as relevant to the changes
- [ ] Updated Build steps/commands changes as relevant
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide description)
- [ ] Specific instructions or information for code reviewers (If any):

Maintainer Mandatory (to be filled by PR Reviewer/Approving Maintainer)
-----------------------------------------------------------------------
- Maintainer who approve the Pull Request for merge are required to mark the checklist below as appropriate for the PR change reviewed as key proof of attestation indicating reasons for merge. 
- Those checklist items which are not marked are considered as not applicable for the PR change. 
- Items marked with an asterisk suffix are mandatory items to check.

### QUALITY CHECKS
- [x] Architectural and Design Fit
- [x] **_Quality of code (At least one should be checked as applicable)\*_**
	- [x] Commit Message meets guidelines
	- [x] PR changes adhere to industry practices and standards
	- [ ] Adopted domain specific coding standards ([SBL Coding Standards](https://github.com/tianocore-docs/Docs/raw/master/Specifications/CCS_2_1_Draft.pdf))
	- [ ] Error and exception code paths implemented correctly
	- [ ] Code reviewed for domain or language specific anti-patterns
	- [ ] Code is adequately commented
	- [x] Code copyright is correct
	- [x] Tracing output are minimized and logic
	- [x] Confusing logic is explained in comments
	- [ ] Commit comment can be used to design a new test case for the changes
- [ ] **_Test coverage shows adequate coverage with required CI functional tests pass on all supported platforms\*_**
- [ ] **_Static code scan report shows zero critical issues\*_**

### CODE REVIEW IMPACT
- Summary of Defects Detected in Code Review: **\<%P1*xx,P2*xx,P3*xx,P4*xx%>** \
Note P1/P2/P3/P4 denotes severity of defects found (Showstopper/High/Medium/Low) and xx denotes number of defects found

# _Code must act as a teacher for future developers_